### PR TITLE
fixed compiling with Qt 5.10 on windows

### DIFF
--- a/src/gifimage/gifimage.pro
+++ b/src/gifimage/gifimage.pro
@@ -1,6 +1,7 @@
+TARGET = QtGifImage
+
 load(qt_module)
 
-TARGET = QtGifImage
 CONFIG += build_gifimage_lib
 include(qtgifimage.pri)
 


### PR DESCRIPTION
should fix errormessage:
No such module: gifimage